### PR TITLE
grid: Enable configuring grid outline thickness

### DIFF
--- a/metadata/grid.xml.in
+++ b/metadata/grid.xml.in
@@ -522,6 +522,13 @@
 		    <default>350</default>
 		    <min>0</min>
 		</option>
+                <option name="outline_thickness" type="int">
+                    <_short>Outline Thickness</_short>
+                    <_long>Outline Thickness</_long>
+                    <default>2</default>
+                    <min>1</min>
+                    <max>8</max>
+                </option>
 		<option name="outline_color" type="color">
 		    <_short>Outline Color</_short>
 		    <_long>Color of the resize indicator outline</_long>

--- a/src/grid/grid.c
+++ b/src/grid/grid.c
@@ -664,7 +664,7 @@ glPaintRectangle (CompScreen		  *s,
 	       ((float) gridGetOutlineColorBlue (s->display) / 65535.0f) * alpha,
 	       alpha);
 
-    glLineWidth (2.0);
+    glLineWidth ((float) gridGetOutlineThickness (s->display));
     glBegin (GL_LINE_LOOP);
 
     /* set outline rect smaller to avoid damage issues */


### PR DESCRIPTION
I didn't see any graphical corruption when testing this. (Note that thickness values over 8 don't seem to have any effect, so I added a maximum to the configuration option in case they have side effects.)
