### PR TITLE
grid: do not use Upper word inconsistently

### DIFF
--- a/metadata/grid.xml.in
+++ b/metadata/grid.xml.in
@@ -69,7 +69,7 @@
 		    <_short>Resize Actions</_short>
 		    <_long>Window resize action</_long>
 		    <option name="top_left_corner_action" type="int">
-			<_short>Upper Left Corner</_short>
+			<_short>Top Left Corner</_short>
 			<_long>Action to be performed when window is dropped on the top left corner</_long>
 			<default>7</default>
 			<min>0</min>
@@ -171,7 +171,7 @@
 			</desc>
 		    </option>
 		    <option name="top_right_corner_action" type="int">
-			<_short>Upper Right Corner</_short>
+			<_short>Top Right Corner</_short>
 			<_long>Action to be performed when window is dropped on the top right corner</_long>
 			<default>9</default>
 			<min>0</min>

--- a/po/ar.po
+++ b/po/ar.po
@@ -926,7 +926,7 @@ msgid "Window resize action"
 msgstr "مسافة النافذة"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "ميول الزوايا"
 
 msgid "Action to be performed when window is dropped on the top left corner"
@@ -972,7 +972,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "ميل الزاوية العليا اليمنى"
 
 msgid "Action to be performed when window is dropped on the top right corner"

--- a/po/bn.po
+++ b/po/bn.po
@@ -919,7 +919,7 @@ msgid "Window resize action"
 msgstr "উইন্ডোর ব্যবধান"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "কোণাগুলি উচু কর"
 
 msgid "Action to be performed when window is dropped on the top left corner"
@@ -964,7 +964,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "ওপরের ডানদিকের কোণা উচু কর"
 
 msgid "Action to be performed when window is dropped on the top right corner"

--- a/po/ca.po
+++ b/po/ca.po
@@ -910,7 +910,7 @@ msgstr "Reflexió"
 msgid "Window resize action"
 msgstr "Direcció de la neu"
 
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr ""
 
 #, fuzzy
@@ -959,7 +959,7 @@ msgstr "Vores"
 msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr ""
 
 #, fuzzy

--- a/po/compiz-plugins-extra.pot
+++ b/po/compiz-plugins-extra.pot
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Window resize action"
 msgstr ""
 
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr ""
 
 msgid "Action to be performed when window is dropped on the top left corner"
@@ -931,7 +931,7 @@ msgstr ""
 msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr ""
 
 msgid "Action to be performed when window is dropped on the top right corner"

--- a/po/cs.po
+++ b/po/cs.po
@@ -908,7 +908,7 @@ msgid "Window resize action"
 msgstr "Písmo titulku okna"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Zakulacené rohy"
 
 #, fuzzy
@@ -958,7 +958,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Zakulatit horní pravý roh"
 
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -997,7 +997,7 @@ msgid "Window resize action"
 msgstr "Fenstertitel-Schrift"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Ecken abrunden"
 
 #, fuzzy
@@ -1046,7 +1046,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Ecke oben rechts abrunden"
 
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -946,7 +946,7 @@ msgid "Window resize action"
 msgstr "Γραμματοσειρά Τίτλου Παραθύρου"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Στρογγύλεμα Γωνίων"
 
 #, fuzzy
@@ -996,7 +996,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Στρογγύλεμα της πάνω δεξιάς γωνίας"
 
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -922,8 +922,8 @@ msgstr "Resize Actions"
 msgid "Window resize action"
 msgstr "Window resize action"
 
-msgid "Upper Left Corner"
-msgstr "Upper Left Corner"
+msgid "Top Left Corner"
+msgstr "Top Left Corner"
 
 msgid "Action to be performed when window is dropped on the top left corner"
 msgstr "Action to be performed when window is dropped on the top left corner"
@@ -961,8 +961,8 @@ msgstr "Top Edge"
 msgid "Action to be performed when window is dropped on the top edge"
 msgstr "Action to be performed when window is dropped on the top edge"
 
-msgid "Upper Right Corner"
-msgstr "Upper Right Corner"
+msgid "Top Right Corner"
+msgstr "Top Right Corner"
 
 msgid "Action to be performed when window is dropped on the top right corner"
 msgstr "Action to be performed when window is dropped on the top right corner"

--- a/po/es.po
+++ b/po/es.po
@@ -978,7 +978,7 @@ msgid "Window resize action"
 msgstr "Fuente de los títulos de las ventanas"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Bisel de Esquinas"
 
 #, fuzzy
@@ -1028,7 +1028,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Bisel esquina superior derecha"
 
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -935,7 +935,7 @@ msgid "Window resize action"
 msgstr "Leiho tituluko letra-mota"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Ertz konikoak"
 
 #, fuzzy
@@ -983,7 +983,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Goiko eskuin ertza konikotu"
 
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -938,7 +938,7 @@ msgid "Window resize action"
 msgstr "Ikkunan otsikon kirjaisin"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Viistota kulmat"
 
 #, fuzzy
@@ -988,7 +988,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Viistota vasen yläkulma"
 
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -962,7 +962,7 @@ msgid "Window resize action"
 msgstr "Police du titre de la fenêtre"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Biseauter les coins"
 
 #, fuzzy
@@ -1012,7 +1012,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Biseauter le coin supérieur droit"
 
 #, fuzzy

--- a/po/gl.po
+++ b/po/gl.po
@@ -941,7 +941,7 @@ msgid "Window resize action"
 msgstr "Fonte do Título da Fiestra"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Bisel das esquinas"
 
 #, fuzzy
@@ -991,7 +991,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Bisel da esquina superior dereita"
 
 #, fuzzy

--- a/po/gu.po
+++ b/po/gu.po
@@ -948,7 +948,7 @@ msgid "Window resize action"
 msgstr "વિન્ડો શીર્ષક ફોન્ટ"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "કોણ ખૂણાઓ"
 
 #, fuzzy
@@ -998,7 +998,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "કોણવાળો ટોચે જમણો ખૂણો"
 
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -927,7 +927,7 @@ msgid "Window resize action"
 msgstr "גופן כותרת חלון"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "החלקת פינות"
 
 #, fuzzy
@@ -977,7 +977,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "החלקת הפינה הימנית העליונה"
 
 #, fuzzy

--- a/po/hi.po
+++ b/po/hi.po
@@ -947,7 +947,7 @@ msgid "Window resize action"
 msgstr "विंडो शीर्षक फ़ॉन्ट"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "बेभेल कोना"
 
 #, fuzzy
@@ -997,7 +997,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "बेभेल ऊपर दायाँ कोना"
 
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -935,7 +935,7 @@ msgid "Window resize action"
 msgstr "Ablak címsorának betűtípusa"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Sarkok lekerekítése"
 
 #, fuzzy
@@ -985,7 +985,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Jobb felső sarok lekerekítése"
 
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -1022,7 +1022,7 @@ msgid "Window resize action"
 msgstr "Carattere titolo della finestra"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Smussa gli angoli"
 
 #, fuzzy
@@ -1072,7 +1072,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Smussa l'angolo in alto a destra"
 
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -926,7 +926,7 @@ msgid "Window resize action"
 msgstr "ウィンドウのタイトルフォント"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "角の面取り"
 
 #, fuzzy
@@ -976,7 +976,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "右上の角の面取り"
 
 #, fuzzy

--- a/po/ko.po
+++ b/po/ko.po
@@ -922,7 +922,7 @@ msgid "Window resize action"
 msgstr "창 제목 글꼴"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "모서리를 둥글게 자름"
 
 #, fuzzy
@@ -972,7 +972,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "오른쪽 상단을 둥글게 자름"
 
 #, fuzzy

--- a/po/nb.po
+++ b/po/nb.po
@@ -952,7 +952,7 @@ msgid "Window resize action"
 msgstr "Skrifttype for vindustittel"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Skråstill hjørner"
 
 #, fuzzy
@@ -1002,7 +1002,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Skråstill øverst, høyre hjørne"
 
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -968,7 +968,7 @@ msgstr "Venster titel lettertype"
 
 # Babelfish geeft "schuine rand" als vertaling voor "Bevel". Dit lijkt me geen geschikte vertaling. - mahler
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Afschuining hoeken"
 
 #, fuzzy
@@ -1018,7 +1018,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Afschuining hoek rechtsboven"
 
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -940,7 +940,7 @@ msgid "Window resize action"
 msgstr "Czcionka tytułu okna"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Zetnij narożniki"
 
 #, fuzzy
@@ -990,7 +990,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Zetnij prawy górny narożnik"
 
 #, fuzzy

--- a/po/pt.po
+++ b/po/pt.po
@@ -950,7 +950,7 @@ msgid "Window resize action"
 msgstr "Fonte do Título da Janela"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Bevel nos cantos"
 
 #, fuzzy
@@ -1000,7 +1000,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Bevel no canto superior direito"
 
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -968,7 +968,7 @@ msgid "Window resize action"
 msgstr "Fonte do Título da Janela"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Chanfrar nos cantos"
 
 #, fuzzy
@@ -1018,7 +1018,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Chanfrar no canto superior direito"
 
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -1014,7 +1014,7 @@ msgid "Window resize action"
 msgstr "Шрифт за_головка окна:"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Скос углов"
 
 #, fuzzy
@@ -1064,7 +1064,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Скос верхнего правого угла"
 
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -940,7 +940,7 @@ msgid "Window resize action"
 msgstr "Typsnitt på fönstertitel"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Runda hörn"
 
 #, fuzzy
@@ -990,7 +990,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Runda det övre högra hörnet"
 
 #, fuzzy

--- a/po/tr.po
+++ b/po/tr.po
@@ -943,7 +943,7 @@ msgid "Window resize action"
 msgstr "Pencere Başlığı Yazı Tipi"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "Köşelere Eğim Ver"
 
 #, fuzzy
@@ -993,7 +993,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "Sağ üst köşe eğimi"
 
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -913,7 +913,7 @@ msgid "Window resize action"
 msgstr "窗口标题字体"
 
 #, fuzzy
-msgid "Upper Left Corner"
+msgid "Top Left Corner"
 msgstr "圆滑边角"
 
 #, fuzzy
@@ -963,7 +963,7 @@ msgid "Action to be performed when window is dropped on the top edge"
 msgstr ""
 
 #, fuzzy
-msgid "Upper Right Corner"
+msgid "Top Right Corner"
 msgstr "圆滑右顶角"
 
 #, fuzzy


### PR DESCRIPTION
Top is mostly used but in some strings Upper was used instead.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>