### PR TITLE
Grid: do not show animations for no-action case

### DIFF
--- a/src/grid/grid.c
+++ b/src/grid/grid.c
@@ -494,6 +494,10 @@ gridHandleEvent (CompDisplay *d,
 			if (where == GridMaximize)
 			    where=GridCenter;
 
+			/* Do not show animation for GridUnknown (no action) */
+			if (where == GridUnknown)
+				return;
+
 			getTargetRect (gs->w, where);
 
 			gs->anim.duration = gridGetAnimationDuration (d);


### PR DESCRIPTION
Enable animations only when hitting a corner or edge is actually set to do something, exclude the "None" case. Previously, setting "None" as action for an edge or corner would still play an animation. 

Fix https://github.com/compiz-reloaded/compiz-plugins-extra/issues/21