### PR TITLE
Makefile.am gtk-update-icon-cache: Respect DESTDIR

### DIFF
--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -30,4 +30,4 @@ icons_DATA =				\
 
 install-data-hook:
 	$(shell which gtk-update-icon-cache &> /dev/null &&	\
-	gtk-update-icon-cache -f -t $(pluginiconsdir))
+	gtk-update-icon-cache -f -t $(DESTDIR)$(pluginiconsdir))


### PR DESCRIPTION
This changes icons/Makefile.am to respect the DESTDIR value when running gtk-update-icon-cache.
Thanks @soreau :)